### PR TITLE
correct message language selection

### DIFF
--- a/pystibmivb/service/STIBService.py
+++ b/pystibmivb/service/STIBService.py
@@ -27,7 +27,7 @@ class STIBService:
         stop_infos = await self._shapefile_service.get_stop_infos(stop_name)
 
         if lang is None or lang == '':
-            lang = ('fr', 'en')
+            lang = ('fr', 'nl')
 
         atomic_stop_infos = stop_infos.get_atomic_stop_infos(line_filters)
         if len(atomic_stop_infos) < 1:

--- a/pystibmivb/service/STIBService.py
+++ b/pystibmivb/service/STIBService.py
@@ -51,7 +51,7 @@ class STIBService:
                     except KeyError:
                         pass
                     try:
-                        if message.upper() == "FIN DE SERVICE" or message.upper() == "EINDE VAN SERVICE":
+                        if message.upper() == "FIN DE SERVICE" or message.upper() == "EINDE DIENST":
                             delta = datetime.timedelta(minutes=42, seconds=42)
                             passages.append(Passage(stop_id=point["pointId"],
                                                     lineId=json_passage["lineId"],


### PR DESCRIPTION
Returned messages are in fr or nl for passingTimes
Closes #6